### PR TITLE
Handle change of return arguments order in astropy>=3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# calviacat v1.0.0
+# calviacat v1.0.1
 Calibrate star photometry by comparison to a catalog.  PanSTARRS 1 and SkyMapper catalogs currently implemented.  Catalog queries are cached so that subsequent calibrations of the same or similar fields can be more quickly executed.
 
 ## Requirements

--- a/calviacat/catalog.py
+++ b/calviacat/catalog.py
@@ -13,6 +13,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.stats import sigma_clipped_stats, sigma_clip
 from astropy.modeling import models, fitting
+from astropy.version import version_info as astropy_version
 
 
 class TableDefinition:
@@ -417,7 +418,11 @@ class Catalog(ABC):
             fitting.LinearLSQFitter(), sigma_clip)
 
         i = np.isfinite(dm) * ~dm.mask
-        line, fit = fitter(model, cindex[i], dm[i])
+        if astropy_version[0] > 3 or (astropy_version[0] == 3 and astropy_version[1] >= 1):
+            # Return order changed in astropy 3.1 (http://docs.astropy.org/en/stable/changelog.html#id10)
+            fit, line = fitter(model, cindex[i], dm[i])
+        else:
+            line, fit = fitter(model, cindex[i], dm[i])
         C = fit.slope.value
         zp = fit.intercept.value
         cal_unc = sigma_clipped_stats((dm - fit(cindex))[i])[2]

--- a/calviacat/catalog.py
+++ b/calviacat/catalog.py
@@ -420,7 +420,9 @@ class Catalog(ABC):
         i = np.isfinite(dm) * ~dm.mask
         if astropy_version[0] > 3 or (astropy_version[0] == 3 and astropy_version[1] >= 1):
             # Return order changed in astropy 3.1 (http://docs.astropy.org/en/stable/changelog.html#id10)
-            fit, line = fitter(model, cindex[i], dm[i])
+            # Also now returns a boolean mask array rather than a MaskedArray of the data which could
+            # be applied back to reconstuct 'line' if needed (not currently used)
+            fit, mask = fitter(model, cindex[i], dm[i])
         else:
             line, fit = fitter(model, cindex[i], dm[i])
         C = fit.slope.value


### PR DESCRIPTION
astropy 3.1 changed the astropy.modelling API for `FittingWithOutlierRemoval`, reversing the order of the return arguments. This patch allows new and old versions of astropy to work the same (without enforcing a minimum version number).