### PR TITLE
Modify fetch_field to allow search around a center with a radius as well

### DIFF
--- a/calviacat/panstarrs1.py
+++ b/calviacat/panstarrs1.py
@@ -8,6 +8,8 @@ import io
 import requests
 import numpy as np
 from astropy.io import votable
+from astropy.coordinates import SkyCoord
+import astropy.units as u
 from .catalog import Catalog, TableDefinition
 
 # column names and SQLite type
@@ -90,28 +92,62 @@ class PanSTARRS1(Catalog):
                               'ramean', 'decmean', filter2col)
         super().__init__(dbfile, ps1, **kwargs)
 
-    def fetch_field(self, sources, scale=1.25):
+    def fetch_field(self, sources, scale=1.25, radius=0.5):
         """Fetch catalog sources for this field and save to database.
 
-        Search radius and center are derived from the source list.
+        Search radius and center are derived from the source list if
+        len(sources) > 1 or from the first entry and radius if there is only
+        a single source.
 
         Parameters
         ----------
-        sources : SkyCoord
-            Sources to be matched.
+        sources : SkyCoord or tuple of (RA center, Dec center) as angle Quantities
+                  or in degrees.
+            Sources to be matched or center to search around.
 
         scale : float, optional
             Search radius scale factor.
 
+        radius: float or Quantity, optional, default=0.5
+            Search radius in degrees or a Quantity that can be transformed
+            to degrees (`scale` is not applied)
         """
-        sr = max((sources.separation(c).max() for c in sources)) * scale / 2
 
+        if type(sources) == SkyCoord:
+            try:
+                sr = max((sources.separation(c).max() for c in sources)) * scale / 2
+                sr = sr.to(u.deg).value
+                ra_center = sources.ra.mean().deg
+                dec_center = sources.dec.mean().deg
+            except TypeError:
+                # single center position given
+                ra_center = sources.ra.deg
+                dec_center = sources.dec.deg
+                try:
+                    sr = radius.to(u.deg).value
+                except AttributeError:
+                    sr = radius
+        elif type(sources) == tuple:
+            ra_center = sources[0]
+            dec_center = sources[1]
+            try:
+                ra_center = ra_center.to(u.deg).value
+                dec_center = dec_center.to(u.deg).value
+            except AttributeError:
+                self.logger.debug("Assuming coordinates are in degrees already")
+                pass
+            except u.UnitConversionError:
+                self.logger.error(("Could not convert {} to center coordinates".format(sources)))
+            try:
+                sr = radius.to(u.deg).value
+            except AttributeError:
+                sr = radius
         self.logger.debug(
-            ('Fetching PS1 catalog from STScI over {:.2g} field-of-view.')
+            ('Fetching PS1 catalog from STScI over {:.2g} deg field-of-view.')
             .format(sr))
 
-        params = dict(RA=sources.ra.mean().deg, DEC=sources.dec.mean().deg,
-                      SR=sr.deg, max_records=self.max_records,
+        params = dict(RA=ra_center, DEC=dec_center, SR=sr,
+                      max_records=self.max_records,
                       ordercolumn1='ndetections',
                       descending1='on',
                       selectedColumnsCsv=','.join(self.table.columns))


### PR DESCRIPTION
Hi @mkelley I have created a branch and pushed code to my fork to allow `fetch_field()` to search around a center with a radius as well. 
I have some additional code that came out of the CSS calibration work to filter sources down to a specific radius (since the field was much larger than the 0.5 deg allowed by the PS1 search) but wasn't sure if you wanted in this branch, a different branch or not at all... I also wasn't sure of the natural home for it (maybe in `caviacat.catalog.Catalog()` ?)  since it operated on Astropy `Table`s to use later on with `xmatch()` and `cal_color()`. Let me know what you think and I can code (or not) accordingly...

Cheers,
Tim